### PR TITLE
Model toolchain fetching using a repository_rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git_repository(
     )
 
 load("@stm32//stm32f4:rules.bzl", "arm_none_repository")
-arm_none_repository()
+arm_none_repository(name="com_arm_developer_toolchain_gcc_6_2")
 ``` 
 ## Available Rules
 

--- a/stm32f4/rules.bzl
+++ b/stm32f4/rules.bzl
@@ -187,22 +187,35 @@ HAL_MODULES = {
 #     "stm32f4xx_ll_usart.c",
 # ]
 
-def arm_none_repository(arch="linux"):
-    if arch == "linux":
-        native.new_http_archive(
-            name = "com_arm_developer_toolchain_gcc_6_2",
-            build_file = str(Label("//compilers:arm_none_gcc_6.2.BUILD")),
-            strip_prefix = "gcc-arm-none-eabi-6-2017-q1-update",
-            url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2"
-            #url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-linux.tar.bz2"
-        )
-    if arch == "mac":
-        native.new_http_archive(
-            name = "com_arm_developer_toolchain_gcc_6_2",
-            build_file = str(Label("//compilers:arm_none_gcc_6.2.BUILD")),
-            strip_prefix = "gcc-arm-none-eabi-6_2-2016q4",
-            url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-mac.tar.bz2"
-        )
+DOWNLOAD_URLS = {
+    "mac os x": ("cb52433610d0084ee85abcd1ac4879303acba0b6a4ecfe5a5113c09f0ee265f0",
+                 "gcc-arm-none-eabi-6_2-2016q4",
+                 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-mac.tar.bz2"),
+    "linux": ("e7aad2579f02e3b095c6d7899ca5e6a70cfa9b8a8cbd6abd868da849d416c2eb",
+              "gcc-arm-none-eabi-6-2017-q1-update",
+              "https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2")
+}
+
+def _arm_none_repository_impl(ctx):
+    download = DOWNLOAD_URLS[ctx.os.name]
+    if not download:
+        fail("Unsupported operating system: {}".format(ctx.os.name))
+    sha256, strip_prefix, url = download;
+
+    ctx.download_and_extract(
+        url=url,
+        sha256=sha256,
+        stripPrefix=strip_prefix
+    )
+
+    ctx.template(
+        "BUILD",
+        Label("//compilers:arm_none_gcc_6.2.BUILD"),
+        substitutions={},
+        executable=False
+    )
+
+arm_none_repository = repository_rule(_arm_none_repository_impl)
 
 def stm32f4_hal_library(name, hdrs=[], modules=[], processor="STM32F407xx", include_path="Inc"):
     my_copts = [ "-I" + include_path, "-D" + processor ]


### PR DESCRIPTION
Hey there!

I've been able to successfully integrate your Bazel build rules into one of my stm32f4 projects (thank you so much for putting your work up!)

One thing that tripped me up was: The fetching of the different gcc toolchains based on the OS I was building from. Since I sometimes build on a mac, and sometimes on Linux, it wasn't tenable to adjust my WORKSPACE every time I was on a different machine (also wouldn't work well with multiple team members who might be using a different OS).

I solved this by moving `arm_none_repository` to be implemented using a Bazel [Repository Rule](https://docs.bazel.build/versions/master/skylark/repository_rules.html), which is the only real way I can find to get access to the current host operating system.

Upsides: Now the same codebase can be built without having to manually update WORKSPACE
Downsides: Still marked as an "experimental" API on the Bazel side, and requires adding a `name` parameter to your workspace during configuration (breaking change for existing WORKSPACEs).

What do you think?